### PR TITLE
suggested to use MIT license and add <wasd> to movement plus a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+LISP ?= sbcl
+
+ql:	
+	$(LISP)	--eval "(ql:register-local-projects)" \
+ 								--eval "(asdf:load-system :tetris)" \
+               				 --eval "(tetris:main)"
+run:
+	$(LISP) --eval "(asdf:load-system :tetris)" \
+                --eval "(tetris:main)"
+
+create:
+	$(LISP)	--eval "(ql:register-local-projects)" \
+ 								--eval "(asdf:load-system :tetris)" \
+               				 --eval "(tetris:make-tetris-command)"
+
+swank:
+	$(LISP) --eval "(ql:quickload '(:swank) :silent t)" \
+                --eval "(swank:create-server :port 5555 :dont-close t)" \
+                --eval "(loop (sleep 1.0))"

--- a/tetris.asd
+++ b/tetris.asd
@@ -3,10 +3,10 @@
 (asdf:defsystem #:tetris
   :description "Describe tetris here"
   :author "Your Name <your.name@example.com>"
-  :license "Specify license here"
+  :license "MIT"
   :serial t
   :depends-on (:cl-charms :alexandria)
   :components ((:file "package")
-	       (:file "console")
+	             (:file "console")
                (:file "tetris")))
 

--- a/tetris.lisp
+++ b/tetris.lisp
@@ -287,13 +287,13 @@
        do (let ((cmdchar (console:get-command)))
 	    (with-game-lock
 	      (case cmdchar
-		(:right (and (check-going-right)
+    ((#\d :right) (and (check-going-right)
 			     (go-right)))
-		(:left (and (check-going-left)
+		((#\a :left) (and (check-going-left)
 			    (go-left)))
-		(:down (and (check-going-down)
+		((#\s :down) (and (check-going-down)
 			    (go-down)))
-		(:up   (and (check-rotating-right)
+		((#\w :up)   (and (check-rotating-right)
 			    (rotate-right)))
 		(#\space (and (check-rotating-left)
 			      (rotate-left)))


### PR DESCRIPTION
As there is no license, the software is hard to be re-used for others.  Hence may I suggest to add a license.  

At the same time, many games use wasd for cursor movement and suggest that as well.  Also, I add in a Makefile to ease the day-to-day operation :-) and highlight the two entry point to the system.

There are two issues outstanding: 
(a) with the setxxx placement but that is only style warning; and 
(b) more problematic is sometimes the main thread does not release the display function and the system hang.  '... The current thread is not at the foreground, SB-THREAD:RELEASE-FOREGROUND has to be called in #<SB-THREAD:THREAD "main thread" ...'  

